### PR TITLE
Fix Rails test database schema error

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,14 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 0) do
+end


### PR DESCRIPTION
Problem:
Running `bin/rails db:test:prepare test test:system` failed with error: "db/schema.rb doesn't exist yet"

Solution:
Ran `bin/rails db:migrate` to generate the missing schema.rb file

Result:
- Successfully created db/schema.rb file
- Test commands now execute without database schema errors